### PR TITLE
feat: Allow pulling CloudFront cert from profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ The included [luggage][7] makefile can be used to create an installer package fo
 3. ```make pkg``` and install.
 4. Set your ```SoftwareRepoURL``` to your CloudFront Distribution address and run munki.
 
+#### Build a profile to set settings
+An alterative to setting values via `defaults` is to use a profile. As of version 1.1, you can now include the CloudFront certificate and all other settings via a profile. This allows easy rotation of the certificate via alterative delivery methods like Mobile Device Management or a configuration management tool. It is still required to drop the `middleware_cloudfront.py` file on disk into the proper directory.
+
+To create a profile use the `create_profile.py` script. See the help menu `--help` for all options. Example usage can be seen below:
+
+    ```
+    ./create_profile.py --cert ~/Desktop/cloudfront.pem --access_id "XXXXXXX" --org_name "Example Org" --desc "Munki CloudFront Settings"
+    ```
+
 [0]: https://github.com/munki/munki
 [1]: https://aws.amazon.com/cloudfront/
 [2]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-creating-cloudfront-key-pairs

--- a/create_profile.py
+++ b/create_profile.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+"""Convert our CloudFront PEM file to a mobileconfig."""
+
+import os
+import plistlib
+import argparse
+import base64
+
+PROFILE_DISPLAY_NAME = 'Munki CloudFront Settings'
+BUNDLE = 'com.github.aaronburchfield.cloudfront'
+PROFILE_FILENAME = 'munki_middleware_cloudfront'
+
+
+def main():
+    """Handle cli arguments and core processing logic."""
+    parser = argparse.ArgumentParser(prog='Munki middleware profile creator',
+                                     description='Create a profile to manage'
+                                     'the munki middleware script.')
+    parser.add_argument('-c', '--cert', required=True,
+                        help='File path to the CloudFront pem encoded '
+                        'certificate.')
+    parser.add_argument('-b', '--base64', default=False,
+                        type=lambda x:
+                            (str(x).lower() in ['true', 'yes', '1']),
+                        help='Encode the certificate as a base64 encoded '
+                        'string instead of the default data type. '
+                        'Accepts: true')
+    parser.add_argument('-e', '--expire_after', required=False,
+                        help='Time in minutes to expire '
+                        'the requests. (Optional)')
+    parser.add_argument('-a', '--access_id', required=False,
+                        help='AWS access_id associated with the CloudFront '
+                        'identity. (Optional)')
+    parser.add_argument('-d', '--domain_name', required=False,
+                        help='Set the alterative domain name if using a '
+                        'domain. (Optional)')
+    parser.add_argument('--org_name', required=False, default='',
+                        help='Set the profile organization. (Optional)')
+    parser.add_argument('--desc', required=False, default='',
+                        help='Set the profile description text. (Optional)')
+    args = parser.parse_args()
+
+    template = {
+        'PayloadUUID': '8217A278-D22A-4591-9620-945E63B6D9B4',
+        'PayloadDescription': args.desc,
+        'PayloadVersion': 1,
+        'PayloadContent': [{
+            'PayloadUUID': '1FF25978-1717-4FD6-967E-DC0DCBEA20A1',
+            'PayloadDescription': args.desc,
+            'PayloadOrganization': args.org_name,
+            'PayloadIdentifier': '1FF25978-1717-4FD6-967E-DC0DCBEA20A1',
+            'PayloadDisplayName': PROFILE_DISPLAY_NAME,
+            'PayloadType': BUNDLE,
+            'PayloadEnabled': True,
+            'PayloadVersion': 1,
+            }],
+        'PayloadIdentifier': BUNDLE,
+        'PayloadDisplayName': PROFILE_DISPLAY_NAME,
+        'PayloadType': 'Configuration',
+        'PayloadScope': 'System',
+        'PayloadEnabled': True,
+        'PayloadOrganization': args.org_name,
+        'PayloadRemovalDisallowed': True
+    }
+
+    cert_file = os.path.abspath(args.cert)
+    print("Certificate file is: {}".format(cert_file))
+
+    with open(cert_file, 'rb') as f:
+        content = f.read()
+
+    # Encode as base64 string or use data type
+    if args.base64:
+        cert_data = base64.b64encode(content)
+    else:
+        cert_data = plistlib.Data(content)
+
+    # Include the certificate in the profile
+    template['PayloadContent'][0]['cloudfront_certificate'] = cert_data
+
+    # Include the AWS access id if passed through
+    if args.access_id:
+        template['PayloadContent'][0]['access_id'] = args.access_id
+
+    # Include a custom expire_time if passed through
+    if args.expire_after:
+        template['PayloadContent'][0]['expire_after'] = args.expire_after
+
+    # Include the alterative domain name if passed through
+    if args.domain_name:
+        template['PayloadContent'][0]['domain_name'] = args.domain_name
+
+    # Write out the profile to disk
+    profile_output = '{}.mobileconfig'.format(PROFILE_FILENAME)
+    plistlib.writePlist(template, profile_output)
+    print("Profile was written to: {}".format(os.path.abspath(profile_output)))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This also includes a basic script to help with the creation of a
profile. I've tested this with both a data object, base64 encoded string, and on disk cert as a fallback. 

Fix: #5 